### PR TITLE
Change /create link to /linkdrop link

### DIFF
--- a/src/near/config.js
+++ b/src/near/config.js
@@ -24,7 +24,7 @@ const configs = {
 const createHelpers = (config) => ({
   getCheckAccountInExplorerUrl: (accountId) => `${config.explorerUrl}/accounts/${accountId}`,
   getCreateAccountAndClaimLink: (secretKey) =>
-    `${config.walletUrl}/create/${config.linkDropContractId}/${secretKey}`,
+    `${config.walletUrl}/linkdrop/${config.linkDropContractId}/${secretKey}`,
 });
 
 const getNearConfig = (network) => {


### PR DESCRIPTION
This allows user to select whether to claim linkdrop on new or existing account

Backport from https://github.com/near-linkdrop/ui.near-linkdrop/pull/2